### PR TITLE
🎉 CI/CD 自動化の追加：Go アプリのビルド＆テスト 🎉

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,39 @@
+# .github/workflows/go-ci.yml
+name: Go CI
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pocketbase  # すべての run ステップで pocketbase をカレントディレクトリに
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'  # 必要に応じて変更
+
+      - name: Install dependencies
+        run: go mod tidy
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build app
+        run: go build -o myapp
+
+      - name: Upload Go App
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-app
+          path: pocketbase/myapp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,18 @@
-# .github/workflows/go-ci.yml
+# Copyright (C) 2025  SUSUMU ONUMA
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 name: Go CI
 
 on:
@@ -12,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./pocketbase  # すべての run ステップで pocketbase をカレントディレクトリに
+        working-directory: ./pocketbase 
 
     steps:
       - name: Checkout code
@@ -20,8 +34,6 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v4
-        with:
-          go-version: '1.22'  # 必要に応じて変更
 
       - name: Install dependencies
         run: go mod tidy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,8 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-name: Go CI
+name: Go CI with Dev Container
 
 on:
   push:
@@ -22,27 +21,21 @@ on:
     branches: [ "*" ]
 
 jobs:
-  build-and-test:
+  devcontainer-ci:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./pocketbase 
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-
-      - name: Install dependencies
-        run: go mod tidy
-
-      - name: Run tests
-        run: go test ./...
-
-      - name: Build app
-        run: go build -o myapp
+      - name: Run Dev Container CI
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            cd pocketbase
+            go mod tidy
+            go test ./...
+            go build -o myapp
 
       - name: Upload Go App
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
このPRでは、GoアプリケーションのCI/CDパイプラインをGitHub Actionsで自動化しました。

主な変更点
Goのセットアップと依存関係のインストール
テストの自動実行 (go test ./...)
ビルドの自動化 (go build)
ビルド成果物のアーティファクトとしてアップロード
メリット
✅ プッシュ・PR時に自動でテストが走るため、品質向上に貢献
✅ アーティファクトがアップロードされるため、後続のデプロイジョブにも活用可能
